### PR TITLE
feat(sdk): handle an sdk zip downloaded as an artifact from github

### DIFF
--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -740,6 +740,7 @@ function handleGitHubArtifact (filepath) {
 			const writeStream = fs.createWriteStream(tempName);
 
 			if (zipfile.entryCount > 1) {
+				zipfile.close();
 				return resolve(filepath);
 			}
 

--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -698,8 +698,9 @@ async function handleInstallArgs(logger, config, cli) {
 			if (await fs.pathExists(file)) {
 				const stat = await fs.stat(file);
 				if (stat.isFile()) {
-					const manifest = await getZippedManifest(file);
-					return new LocalSDKInstallRequest(logger, config, cli, file, manifest);
+					const zipFile = await handleGitHubArtifact(file);
+					const manifest = await getZippedManifest(zipFile);
+					return new LocalSDKInstallRequest(logger, config, cli, zipFile, manifest);
 				}
 			}
 		}
@@ -715,6 +716,53 @@ async function handleInstallArgs(logger, config, cli) {
 		return doBranch(logger, config, cli, version, branch, osName);
 	}
 	return doReleases(logger, config, cli, version, osName);
+}
+
+/**
+ * Validates the zip that has been requested to be installed. This is because when downloading a
+ * GitHub artifact the actual SDK zip will be placed inside a zip which will cause the extract to
+ * fail. If this zip is a GitHub artifact then it will be unzipped and the resulting zip will be
+ * returned
+ *
+ * @param {String} filepath - The path to the zip.
+ * @returns {String} - The correct path to install.
+ */
+function handleGitHubArtifact (filepath) {
+	return new Promise((resolve, reject) => {
+		const yauzl = require('yauzl');
+		yauzl.open(filepath, { lazyEntries: true }, (err, zipfile) => {
+			if (err) {
+				return reject(err);
+			}
+
+			const temp = require('temp');
+			const tempName = temp.path({ suffix: '.zip' });
+			const writeStream = fs.createWriteStream(tempName);
+
+			if (zipfile.entryCount > 1) {
+				return resolve(filepath);
+			}
+
+			zipfile.once('close', () => {
+				return resolve(tempName);
+			});
+			zipfile.once('error', err => reject(err));
+
+			zipfile.on('entry', (entry) => {
+				zipfile.openReadStream(entry, (err, readStream) => {
+					if (err) {
+						return reject(err);
+					}
+					readStream.on('end', () => {
+						zipfile.readEntry();
+					});
+					readStream.pipe(writeStream);
+				});
+			});
+
+			zipfile.readEntry();
+		});
+	});
 }
 
 /**


### PR DESCRIPTION
This is an attempt at handling an SDK downloaded from GitHub artifacts (i.e. from a branch or PR build) when passed as a local zip argument.

I need to fully validate if this adds too much overhead to the process for normal zips (I don't think it should as we just open and check the total files inside) and maybe see about adding some feedback to the user about what is going on.