### PR TITLE
feat(sdk): add timestamp flag

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -39,7 +39,8 @@ var path = require('path'),
 	debugColor = process.platform === 'win32' && process.title.indexOf('PowerShell') >= 0 ? 'cyan' : 'magenta',
 	origLoggerLog = logger.log,
 	bannerEnabled = true,
-	bannerWasRendered = false;
+	bannerWasRendered = false,
+	timestampEnabled = false;
 
 module.exports = logger;
 
@@ -110,6 +111,13 @@ logger.bannerEnabled = function (b) {
 	return bannerEnabled;
 };
 
+logger.timestampEnabled = function (b) {
+	if (b !== undefined) {
+		timestampEnabled = !!b;
+	}
+	return timestampEnabled;
+};
+
 logger.bannerWasRendered = function () {
 	return bannerWasRendered;
 };
@@ -142,7 +150,7 @@ consoul.log = function (level, msg, meta, callback) {
 		message:     msg,
 		meta:        meta,
 		stringify:   this.stringify,
-		timestamp:   this.timestamp,
+		timestamp:   timestampEnabled,
 		prettyPrint: this.prettyPrint,
 		raw:         this.raw
 	});

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -252,6 +252,14 @@ function run(locale) {
 				hideDefault: true,
 				negate: true
 			},
+			timestamp: {
+				callback: function (value) {
+					logger.timestampEnabled(!!value);
+				},
+				default: config.get('cli.timestamp', false),
+				desc: __('displays a timestamp in front of log lines'),
+				hideDefault: true
+			},
 			'progress-bars': {
 				default: process.stdout.isTTY ? config.get('cli.progressBars', true) : false,
 				desc: __('disable progress bars'),


### PR DESCRIPTION
Add a `--timestamp` or `ti config cli.timestamp true` flag to the CLI. It will display a timestamp (already implemented) before the log output:
```
2022-04-07T09:13:04.546Z - [INFO]  
```