### PR TITLE
fix: download correct rc or ga release

### DIFF
--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -1444,10 +1444,10 @@ exports.getReleases = async function getReleases(config, os) {
 		// Paginate through the releases on the repo, and determine which of the assets
 		// is correct for the platform we're running on
 		const releaseData = await octokit.paginate(paginateData);
-		const osRegex = /mobilesdk-\d+\.\d+\.\d+\.GA-(\w+)\.zip/;
+		const osRegex = /mobilesdk-\d+\.\d+\.\d+\.([A-Z)]{2})-(\w+)\.zip/;
 		for (let { assets, name } of releaseData) {
 			const release = assets.find(asset => {
-				const [ , assetOS ] = osRegex.exec(asset.name);
+				const [ , versionType, assetOS ] = osRegex.exec(asset.name);
 				if (assetOS === os) {
 					return asset.url;
 				}
@@ -1455,7 +1455,10 @@ exports.getReleases = async function getReleases(config, os) {
 			});
 
 			if (release) {
-				name = name.includes('GA') ? name : `${name}.GA`;
+				const analyseVersionRegExp = /(\d+\.\d+\.\d+)(\.)*([A-Z)]{2})*/;
+				const [ , version, dot, versionType ] = analyseVersionRegExp.exec(name);
+				// Fallback in GA version for backward compatibility
+				name = !versionType || !dot ? `${version}.GA` : `${version}.${versionType}`;
 				releases.set(name, { url: release.browser_download_url });
 			}
 		}

--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -926,7 +926,13 @@ async function doReleases(logger, config, cli, version, osName) {
 
 	// if choosing latest, resolve to latest listed releases
 	if (isLatest) {
-		version = rels[0];
+		rels.every((availableVersion) => {
+			if (availableVersion.endsWith('GA')) {
+				version = availableVersion;
+				return false;
+			}
+			return true;
+		});
 	}
 
 	if (releases.has(version)) {
@@ -1447,7 +1453,7 @@ exports.getReleases = async function getReleases(config, os) {
 		const osRegex = /mobilesdk-\d+\.\d+\.\d+\.([A-Z)]{2})-(\w+)\.zip/;
 		for (let { assets, name } of releaseData) {
 			const release = assets.find(asset => {
-				const [ , versionType, assetOS ] = osRegex.exec(asset.name);
+				const [ , , assetOS ] = osRegex.exec(asset.name);
 				if (assetOS === os) {
 					return asset.url;
 				}


### PR DESCRIPTION
This PR fixes the download of the correct RC or GA version of the SDK.

To test, just try
`ti sdk install latest`
`ti sdk install 11.0.0.RC`
`ti sdk install 10.1.1.GA`

If you have already installed a version use `--force`

Big kudos to **Bruno**, who make this PR possible