### PR TITLE
fix: correctly detect GA releases during sdk list and install

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -15,10 +15,9 @@
  */
 'use strict';
 
-var config = require('../config'),
-	appc = require('node-appc'),
-	__ = appc.i18n(__dirname).__,
-	fs = require('fs');
+const appc = require('node-appc');
+const __ = appc.i18n(__dirname).__;
+const fs = require('fs');
 
 /** Help command description. */
 exports.desc = __('displays this help screen');

--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -35,15 +35,15 @@ const __ = appc.i18n(__dirname).__;
 
 const callbackify = require('util').callbackify;
 
-const baseUrl = process.env.APPC_ENV === 'preproduction'
-	? 'https://7b0d820e62858b06f261b713941877354db8fa39.cloudapp-enterprise-preprod.appctest.com'
-	: 'https://f4df0833a1352ef193633d85356e6e80ffcdcdb7.cloudapp-enterprise.appcelerator.com';
-const urls = {
-	branches: baseUrl + '/api/mobilesdk/branches/$TOKEN',
-	branch: baseUrl + '/api/mobilesdk/branch/$BRANCH/$TOKEN',
-	build: baseUrl + '/api/mobilesdk/build/$BRANCH/$FILENAME/$TOKEN',
-	releases: baseUrl + '/api/mobilesdk/releases/$TOKEN'
-};
+// const baseUrl = process.env.APPC_ENV === 'preproduction'
+// 	? 'https://7b0d820e62858b06f261b713941877354db8fa39.cloudapp-enterprise-preprod.appctest.com'
+// 	: 'https://f4df0833a1352ef193633d85356e6e80ffcdcdb7.cloudapp-enterprise.appcelerator.com';
+// const urls = {
+// 	branches: baseUrl + '/api/mobilesdk/branches/$TOKEN',
+// 	branch: baseUrl + '/api/mobilesdk/branch/$BRANCH/$TOKEN',
+// 	build: baseUrl + '/api/mobilesdk/build/$BRANCH/$FILENAME/$TOKEN',
+// 	releases: baseUrl + '/api/mobilesdk/releases/$TOKEN'
+// };
 
 /** SDK command title. */
 exports.title = __('SDK');
@@ -123,7 +123,7 @@ SdkSubcommands.list = {
 			flags: {
 				branches: {
 					abbr: 'b',
-					desc: __('retrieve and print all branches')
+					desc: __('retrieve and print all branches; %s', 'currently unavailable'.yellow)
 				},
 				releases: {
 					abbr: 'r',
@@ -132,7 +132,7 @@ SdkSubcommands.list = {
 			},
 			options: {
 				branch: {
-					desc: __('branch to fetch CI builds')
+					desc: __('branch to fetch CI builds; %s', 'currently unavailable'.yellow)
 				},
 				output: {
 					abbr: 'o',
@@ -156,7 +156,7 @@ async function list(logger, config, cli) {
 
 	const tasks = [];
 	// Gather releases?
-	tasks.push(cli.argv.releases ? errorAsResult(exports.getReleases(config, osName)) : Promise.resolve());
+	tasks.push(cli.argv.releases ? errorAsResult(getReleases(config, osName)) : Promise.resolve());
 	// Gather branches?
 	tasks.push(cli.argv.branches ? errorAsResult(getBranches(config, logger)) : Promise.resolve());
 	// Gather builds from specific branch?
@@ -166,7 +166,7 @@ async function list(logger, config, cli) {
 	// (and not just toss an Error up the stack)
 	const [ releases, branches, branchBuilds ] = await Promise.all(tasks);
 
-	const sdks = cli.env.sdks;
+	const { sdks } = cli.env;
 	const vers = appc.version.sort(Object.keys(sdks)).reverse();
 
 	let activeSDK = config.get('sdk.selected', config.get('app.sdk'));
@@ -230,46 +230,45 @@ async function list(logger, config, cli) {
 	}
 
 	logger.banner();
-	if (!vers.length) {
-		// TODO: Don't return, just guard the sdk listing code below
-		logger.log(__('No Titanium SDKs are installed') + '\n');
-		logger.log(__('You can download the latest Titanium SDK by running: %s', (cli.argv.$ + ' sdk install').cyan) + '\n');
-		return;
-	}
-
 	logger.log(__('SDK Install Locations:'));
 	locations.sort().forEach(p => {
 		logger.log('   ' + p.cyan + (p === defaultInstallLocation ? (' [' + __('default') + ']').grey : ''));
 	});
 	logger.log();
 
-	const activeLabel = ' [' + __('selected') + ']';
-	const maxlen = vers.reduce(function (a, b) {
-		return Math.max(a, b.length + (b === activeSDK ? activeLabel.length : 0));
-	}, 0);
-	const maxname = vers.reduce(function (a, b) {
-		return Math.max(a, sdks[b].manifest && sdks[b].manifest.name ? sdks[b].manifest.name.length : 0);
-	}, 0);
-
-	logger.log(__('Installed SDKs:'));
 	let activeValid = false;
-	vers.forEach(function (v) {
-		var d = v === activeSDK ? activeLabel : '',
-			n = maxlen + 2 - v.length - d.length,
-			name = sdks[v].manifest && (sdks[v].manifest.name || sdks[v].manifest.version);
 
-		if (!name) {
-			try {
-				name = appc.version.format(v, 3, 3);
-			} catch (ex) {
-				// ignore
+	if (vers.length) {
+		const activeLabel = ' [' + __('selected') + ']';
+		const maxlen = vers.reduce(function (a, b) {
+			return Math.max(a, b.length + (b === activeSDK ? activeLabel.length : 0));
+		}, 0);
+		const maxname = vers.reduce(function (a, b) {
+			return Math.max(a, sdks[b].manifest && sdks[b].manifest.name ? sdks[b].manifest.name.length : 0);
+		}, 0);
+
+		logger.log(__('Installed SDKs:'));
+		vers.forEach(function (v) {
+			var d = v === activeSDK ? activeLabel : '',
+				n = maxlen + 2 - v.length - d.length,
+				name = sdks[v].manifest && (sdks[v].manifest.name || sdks[v].manifest.version);
+
+			if (!name) {
+				try {
+					name = appc.version.format(v, 3, 3);
+				} catch (ex) {
+					// ignore
+				}
 			}
-		}
 
-		activeValid = activeValid || v === activeSDK;
-		logger.log('   ' + v.cyan + d.grey + new Array(n + 1).join(' ') + (maxname ? appc.string.rpad(name ? name : '', maxname + 2).magenta : '') + sdks[v].path);
-	});
-	logger.log();
+			activeValid = activeValid || v === activeSDK;
+			logger.log('   ' + v.cyan + d.grey + new Array(n + 1).join(' ') + (maxname ? appc.string.rpad(name ? name : '', maxname + 2).magenta : '') + sdks[v].path);
+		});
+		logger.log();
+	} else {
+		logger.log(__('No Titanium SDKs are installed') + '\n');
+		logger.log(__('You can download the latest Titanium SDK by running: %s', (cli.argv.$ + ' sdk install').cyan) + '\n');
+	}
 
 	if (releases) {
 		logger.log(__('Releases:'));
@@ -340,7 +339,7 @@ async function list(logger, config, cli) {
 		}
 	}
 
-	if (!activeValid) {
+	if (vers.length && !activeValid) {
 		logger.error(__('Selected Titanium SDK \'%s\' not found', activeSDK) + '\n');
 		logger.log(__('Run \'%s\' to set the selected Titanium SDK.', (cli.argv.$ + ' sdk select <sdk-version>').cyan) + '\n');
 	}
@@ -567,14 +566,14 @@ SdkSubcommands.install = {
 					abbr: 'k',
 					desc: __('keep downloaded files after install'),
 				}
-			},
-			options: {
-				branch: {
-					abbr: 'b',
-					desc: __('the branch to install from or "latest" (stable)'),
-					hint: __('branch name')
-				}
 			}
+			// options: {
+			// 	branch: {
+			// 		abbr: 'b',
+			// 		desc: __('the branch to install from or "latest" (stable)'),
+			// 		hint: __('branch name')
+			// 	}
+			// }
 		};
 	},
 	fn: callbackify(install)
@@ -680,8 +679,9 @@ async function ensureInstallLocation(installLocation) {
  */
 async function handleInstallArgs(logger, config, cli) {
 	const version = cli.argv.version;
-	const branch = cli.argv.branch;
+	// const branch = cli.argv.branch;
 	const osName = cli.env.os.name;
+
 	if (version) {
 		// version is a URL?
 		if (/^http(s)?:\/\/.+/.test(version)) {
@@ -702,15 +702,15 @@ async function handleInstallArgs(logger, config, cli) {
 		}
 
 		// version is a git hash?
-		const match = version.match(/^([A-Za-z0-9_]+?):(.+)$/);
-		if (match) {
-			return doBranch(logger, config, cli, match[2], match[1], osName);
-		}
+		// const match = version.match(/^([A-Za-z0-9_]+?):(.+)$/);
+		// if (match) {
+		// 	return doBranch(logger, config, cli, match[2], match[1], osName);
+		// }
 	}
 
-	if (branch) {
-		return doBranch(logger, config, cli, version, branch, osName);
-	}
+	// if (branch) {
+	// 	return doBranch(logger, config, cli, version, branch, osName);
+	// }
 	return doReleases(logger, config, cli, version, osName);
 }
 
@@ -723,7 +723,7 @@ async function handleInstallArgs(logger, config, cli) {
  * @param {String} filepath - The path to the zip.
  * @returns {String} - The correct path to install.
  */
-function handleGitHubArtifact (filepath) {
+function handleGitHubArtifact(filepath) {
 	return new Promise((resolve, reject) => {
 		const yauzl = require('yauzl');
 		yauzl.open(filepath, { lazyEntries: true }, (err, zipfile) => {
@@ -840,37 +840,37 @@ async function getZippedManifest(filepath) {
  * @param {string} osName 'linux' || 'osx' || 'win32'
  * @returns {Promise<SDKInstallRequest>}
  */
-async function doBranch(logger, config, cli, version, branch, osName) {
-	branch = await getBranch(branch, config, logger);
+// async function doBranch(logger, config, cli, version, branch, osName) {
+// 	branch = await getBranch(branch, config, logger);
 
-	const builds = await getBranchBuilds(config, branch, osName);
-	if (!builds || !builds.length) {
-		throw new Error(__('Branch \'%s\' does not have any builds', branch) + '\n');
-	}
+// 	const builds = await getBranchBuilds(config, branch, osName);
+// 	if (!builds || !builds.length) {
+// 		throw new Error(__('Branch \'%s\' does not have any builds', branch) + '\n');
+// 	}
 
-	const isLatest = !version || version === 'latest';
-	const build = isLatest ? builds[0] : builds.filter(b => b.name === version).shift();
+// 	const isLatest = !version || version === 'latest';
+// 	const build = isLatest ? builds[0] : builds.filter(b => b.name === version).shift();
 
-	if (!build) {
-		const buildNames = builds.map(b => b.name).sort().reverse();
-		let str = '';
-		appc.string.suggest(version, buildNames, s => {
-			str += (s || '') + '\n';
-		}, 2);
-		str += __('Available Builds:\n');
-		str += appc.string.renderColumns(buildNames, '    ', 100).cyan + '\n';
-		throw new CLIError(__('Build "%s" does not exist\n', version), str);
-	}
+// 	if (!build) {
+// 		const buildNames = builds.map(b => b.name).sort().reverse();
+// 		let str = '';
+// 		appc.string.suggest(version, buildNames, s => {
+// 			str += (s || '') + '\n';
+// 		}, 2);
+// 		str += __('Available Builds:\n');
+// 		str += appc.string.renderColumns(buildNames, '    ', 100).cyan + '\n';
+// 		throw new CLIError(__('Build "%s" does not exist\n', version), str);
+// 	}
 
-	version = build.name;
+// 	version = build.name;
 
-	return new SDKInstallRequest(logger, config, cli, {
-		url: urls.build.replace(/\$BRANCH/, branch).replace(/\$FILENAME/, build.filename).replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'),
-		version,
-		branch,
-		isLatest
-	});
-}
+// 	return new SDKInstallRequest(logger, config, cli, {
+// 		url: urls.build.replace(/\$BRANCH/, branch).replace(/\$FILENAME/, build.filename).replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'),
+// 		version,
+// 		branch,
+// 		isLatest
+// 	});
+// }
 
 /**
  * @param {string} branch branch name to validate/get, use 'latest' to pick default branch
@@ -879,31 +879,31 @@ async function doBranch(logger, config, cli, version, branch, osName) {
  * @returns {Promise<string>} validated/resolved branch name
  * @throws {Error} if no branches are found, or if named barnch is not found in listing
  */
-async function getBranch(branch, config, logger) {
-	const data = await getBranches(config, logger);
+// async function getBranch(branch, config, logger) {
+// 	const data = await getBranches(config, logger);
 
-	// check that we have branches
-	if (!data || !data.branches.length) {
-		throw new Error(__('No branches found!') + '\n');
-	}
+// 	// check that we have branches
+// 	if (!data || !data.branches.length) {
+// 		throw new Error(__('No branches found!') + '\n');
+// 	}
 
-	// resolve 'latest' alias
-	if (branch === 'latest') {
-		branch = data.defaultBranch;
-	}
+// 	// resolve 'latest' alias
+// 	if (branch === 'latest') {
+// 		branch = data.defaultBranch;
+// 	}
 
-	// check that the desired branch exists
-	if (!data.branches.includes(branch)) {
-		let str = '';
-		appc.string.suggest(branch, data.branches, s => {
-			str += (s || '') + '\n';
-		}, 2);
-		str += __('Available Branches:\n');
-		str += appc.string.renderColumns(data.branches.sort().reverse(), '    ', 100).cyan + '\n';
-		throw new CLIError(__('Branch "%s" does not exist\n', branch), str);
-	}
-	return branch;
-}
+// 	// check that the desired branch exists
+// 	if (!data.branches.includes(branch)) {
+// 		let str = '';
+// 		appc.string.suggest(branch, data.branches, s => {
+// 			str += (s || '') + '\n';
+// 		}, 2);
+// 		str += __('Available Branches:\n');
+// 		str += appc.string.renderColumns(data.branches.sort().reverse(), '    ', 100).cyan + '\n';
+// 		throw new CLIError(__('Branch "%s" does not exist\n', branch), str);
+// 	}
+// 	return branch;
+// }
 
 /**
  * @param {Object} logger - The logger instance
@@ -916,7 +916,7 @@ async function getBranch(branch, config, logger) {
  */
 async function doReleases(logger, config, cli, version, osName) {
 	// check if it's a valid release
-	const releases = await exports.getReleases(config, osName);
+	const releases = await getReleases(config, osName, { allReleaseTypes: true });
 	if (!releases || releases.size === 0) {
 		throw new Error(__('No releases found!') + '\n');
 	}
@@ -926,7 +926,7 @@ async function doReleases(logger, config, cli, version, osName) {
 
 	// if choosing latest, resolve to latest listed releases
 	if (isLatest) {
-		version = rels[0];
+		version = rels.find(ver => releases.get(ver).releaseType === 'GA');
 	}
 
 	if (releases.has(version)) {
@@ -940,23 +940,25 @@ async function doReleases(logger, config, cli, version, osName) {
 		});
 	}
 
-	logger.log(__('Did not find a release %s, scanning branches...', version.cyan));
-	const matchingBuild = await scanBranches(logger, config, cli, version, osName);
-	if (!matchingBuild) {
-		let str = '';
-		if (!cli.argv.branch && version.indexOf('.v') !== -1) {
-			str += __('Did you forget to specify the branch?') + '\n';
-		}
-		appc.string.suggest(version, rels, s => {
-			str += (s || '') + '\n';
-		}, 1);
-		str += __('Available Releases:\n');
-		str += appc.string.renderColumns(rels, '    ', 100).cyan + '\n';
-		throw new CLIError(__('Release "%s" does not exist\n', version), str);
-	}
+	throw new CLIError(__('Unable to find SDK release "%s"', version));
 
-	logger.log(__('Found build %s in branch %s', version.cyan, matchingBuild.branch.cyan) + '\n');
-	return matchingBuild;
+	// logger.log(__('Did not find a release %s, scanning branches...', version.cyan));
+	// const matchingBuild = await scanBranches(logger, config, cli, version, osName);
+	// if (!matchingBuild) {
+	// 	let str = '';
+	// 	if (!cli.argv.branch && version.indexOf('.v') !== -1) {
+	// 		str += __('Did you forget to specify the branch?') + '\n';
+	// 	}
+	// 	appc.string.suggest(version, rels, s => {
+	// 		str += (s || '') + '\n';
+	// 	}, 1);
+	// 	str += __('Available Releases:\n');
+	// 	str += appc.string.renderColumns(rels, '    ', 100).cyan + '\n';
+	// 	throw new CLIError(__('Release "%s" does not exist\n', version), str);
+	// }
+
+	// logger.log(__('Found build %s in branch %s', version.cyan, matchingBuild.branch.cyan) + '\n');
+	// return matchingBuild;
 }
 
 /**
@@ -968,38 +970,38 @@ async function doReleases(logger, config, cli, version, osName) {
  * @returns {Promise<SDKInstallRequest>} metadata for the build seletced/found
  * @throws {Error} if unable to find the requested version in any branch
  */
-async function scanBranches(logger, config, cli, version, osName) {
-	const data = await getBranches(config, logger);
-	if (!data || !Array.isArray(data.branches)) {
-		throw new Error('Unable to find any branches');
-	}
+// async function scanBranches(logger, config, cli, version, osName) {
+// 	const data = await getBranches(config, logger);
+// 	if (!data || !Array.isArray(data.branches)) {
+// 		throw new Error('Unable to find any branches');
+// 	}
 
-	// TODO: Be smarter with version, we should generally "know" the expected branch name to check
-	// i.e. "9.2.0.v..." should check like 'master' and '9_2_X'
+// 	// TODO: Be smarter with version, we should generally "know" the expected branch name to check
+// 	// i.e. "9.2.0.v..." should check like 'master' and '9_2_X'
 
-	// Now in parallel, check all branches listed?
-	let matchingBuild;
-	await Promise.all(data.branches.map(async branch => {
-		if (matchingBuild) {
-			return;
-		}
+// 	// Now in parallel, check all branches listed?
+// 	let matchingBuild;
+// 	await Promise.all(data.branches.map(async branch => {
+// 		if (matchingBuild) {
+// 			return;
+// 		}
 
-		const builds = await getBranchBuilds(config, branch, osName);
-		if (!matchingBuild && Array.isArray(builds)) {
-			for (const build of builds) {
-				if (build.name === version) {
-					matchingBuild = {
-						url: urls.build.replace(/\$BRANCH/, branch).replace(/\$FILENAME/, build.filename).replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'),
-						version,
-						branch
-					};
-					break;
-				}
-			}
-		}
-	}));
-	return new SDKInstallRequest(logger, config, cli, matchingBuild);
-}
+// 		const builds = await getBranchBuilds(config, branch, osName);
+// 		if (!matchingBuild && Array.isArray(builds)) {
+// 			for (const build of builds) {
+// 				if (build.name === version) {
+// 					matchingBuild = {
+// 						url: urls.build.replace(/\$BRANCH/, branch).replace(/\$FILENAME/, build.filename).replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'),
+// 						version,
+// 						branch
+// 					};
+// 					break;
+// 				}
+// 			}
+// 		}
+// 	}));
+// 	return new SDKInstallRequest(logger, config, cli, matchingBuild);
+// }
 
 /**
  * @typedef {Object} Branches
@@ -1013,16 +1015,17 @@ async function scanBranches(logger, config, cli, version, osName) {
  * @param {Object} logger - The logger object
  * @returns {Promise<Branches>}
  */
-async function getBranches(config, logger) {
-	try {
-		logger.warn('Branch builds will become unavailable after March 1st 2022. It is recommended that you download and store any zip files for branch builds that you require.');
-		return await fetch(urls.branches, config);
-	} catch (error) {
-		if (error.statusCode === 404 || error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
-			throw new CLIError('Failed to retrieve branch builds, this is most likely as branch builds as no longer available.');
-		}
-		throw error;
-	}
+async function getBranches() { // config, logger) {
+	// try {
+	// 	logger.warn('Branch builds will become unavailable after March 1st 2022. It is recommended that you download and store any zip files for branch builds that you require.');
+	// 	return await fetch(urls.branches, config);
+	// } catch (error) {
+	// 	if (error.statusCode === 404 || error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
+	// 		throw new CLIError('Failed to retrieve branch builds, this is most likely as branch builds as no longer available.');
+	// 	}
+	// 	throw error;
+	// }
+	throw new CLIError('Branch builds are currently unavailable');
 }
 
 /**
@@ -1424,14 +1427,17 @@ async function uninstall(logger, config, cli) {
  * Retrieves the list of releases.
  * @param {Object} config - The CLI config object
  * @param {String} os - The name of the OS (osx, linux, win32)
+ * @param {Object} [opts] - Misc options
+ * @param {Boolean} [opts.allReleaseTypes] - When `true`, returns GA, RC, and beta releases
  * @returns {Promise<Map<string, Release>>}
  */
-exports.getReleases = async function getReleases(config, os) {
+async function getReleases(config, os, opts = {}) {
 	const auth = config.get('sdk.github.token', process.env.GITHUB_TOKEN);
 	const octokit = new Octokit({ auth });
+	const { allReleaseTypes } = opts;
 
 	// Setting these in the config shouldn't be necessary but it's included just incase it's needed
-	const owner = config.get('sdk.github.owner', 'appcelerator');
+	const owner = config.get('sdk.github.owner', 'tidev');
 	const repo = config.get('sdk.github.repo', 'titanium_mobile');
 
 	const paginateData = octokit.repos.listReleases.endpoint.merge({
@@ -1444,19 +1450,25 @@ exports.getReleases = async function getReleases(config, os) {
 		// Paginate through the releases on the repo, and determine which of the assets
 		// is correct for the platform we're running on
 		const releaseData = await octokit.paginate(paginateData);
-		const osRegex = /mobilesdk-\d+\.\d+\.\d+\.GA-(\w+)\.zip/;
+		const osRegex = /^mobilesdk-\d+\.\d+\.\d+\.(\w+)-(\w+)\.zip$/;
+		const releaseRegex = /^\d+\.\d+\.\d+\.(\w+)$/;
+
 		for (let { assets, name } of releaseData) {
 			const release = assets.find(asset => {
-				const [ , assetOS ] = osRegex.exec(asset.name);
-				if (assetOS === os) {
+				const m = asset.name.match(osRegex);
+				if (m && m[2] === os && (allReleaseTypes || m[1] === 'GA')) {
 					return asset.url;
 				}
 				return false;
 			});
 
 			if (release) {
-				name = name.includes('GA') ? name : `${name}.GA`;
-				releases.set(name, { url: release.browser_download_url });
+				const m = name.match(releaseRegex);
+				name = m ? name : `${name}.GA`;
+				releases.set(name, {
+					releaseType: m && m[1] || 'GA',
+					url: release.browser_download_url
+				});
 			}
 		}
 		return releases;
@@ -1472,7 +1484,9 @@ exports.getReleases = async function getReleases(config, os) {
 		}
 		throw new Error(`Failed to retrieve release.\n${message}`);
 	}
-};
+}
+
+exports.getReleases = getReleases;
 
 /**
  * The parsed metadata for a list of builds from a single branch's JSON file
@@ -1498,25 +1512,26 @@ exports.getReleases = async function getReleases(config, os) {
  * @param {String} osName - The name of the current OS (osx, linux, win32)
  * @returns {Promise<BranchBuild[]>}
  */
-async function getBranchBuilds(config, branch, osName) {
-	// const moment = require('moment'); // Replaced with toLocaleString()
-	const data = await fetch(urls.branch.replace(/\$BRANCH/, branch).replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'), config);
+async function getBranchBuilds() { // config, branch, osName) {
+	// // const moment = require('moment'); // Replaced with toLocaleString()
+	// const data = await fetch(urls.branch.replace(/\$BRANCH/, branch).replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'), config);
 
-	// filter to builds for this os
-	const osBuilds = data.filter(f => f.filename.includes(osName));
-	// supplement the properties for a given build
-	const modifiedBuilds = osBuilds.map(b => {
-		const p = b.filename.match(/^mobilesdk-(.+)(?:\.v|-)((\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2}))-([^.]+)/);
-		b.version = p[1];
-		b.name = p[1] + '.v' + p[2];
-		b.ts = p[2]; // i.e. '20200915080356'
-		b.date = new Date(p.slice(4, 6).join('/') + '/' + p[3] + ' ' + p.slice(6, 9).join(':'));
-		// b.dateFormatted = moment(b.date).format('l LT');
-		b.dateFormatted = b.date.toLocaleString(); // TODO: drop any commas for en-US?
-		return b;
-	});
-	// return builds latest to oldest (by timestamp)
-	return modifiedBuilds.sort((a, b) => b.ts - a.ts);
+	// // filter to builds for this os
+	// const osBuilds = data.filter(f => f.filename.includes(osName));
+	// // supplement the properties for a given build
+	// const modifiedBuilds = osBuilds.map(b => {
+	// 	const p = b.filename.match(/^mobilesdk-(.+)(?:\.v|-)((\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2}))-([^.]+)/);
+	// 	b.version = p[1];
+	// 	b.name = p[1] + '.v' + p[2];
+	// 	b.ts = p[2]; // i.e. '20200915080356'
+	// 	b.date = new Date(p.slice(4, 6).join('/') + '/' + p[3] + ' ' + p.slice(6, 9).join(':'));
+	// 	// b.dateFormatted = moment(b.date).format('l LT');
+	// 	b.dateFormatted = b.date.toLocaleString(); // TODO: drop any commas for en-US?
+	// 	return b;
+	// });
+	// // return builds latest to oldest (by timestamp)
+	// return modifiedBuilds.sort((a, b) => b.ts - a.ts);
+	throw new CLIError('Branch builds are currently unavailable');
 }
 
 /**
@@ -1525,33 +1540,33 @@ async function getBranchBuilds(config, branch, osName) {
  * @param {Object} config - The CLI config object
  * @returns {Promise<Object>}
  */
-async function fetch(url, config) {
-	return new Promise((resolve, reject) => {
-		request({
-			url: url.replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'),
-			proxy: config.get('cli.httpProxyServer'),
-			rejectUnauthorized: config.get('cli.rejectUnauthorized', true)
-		}, function (error, response, body) {
-			if (error) {
-				return reject(error);
-			}
+// async function fetch(url, config) {
+// 	return new Promise((resolve, reject) => {
+// 		request({
+// 			url: url.replace(/\$TOKEN/, process.env.APPC_SESSION_TOKEN || 'X'),
+// 			proxy: config.get('cli.httpProxyServer'),
+// 			rejectUnauthorized: config.get('cli.rejectUnauthorized', true)
+// 		}, function (error, response, body) {
+// 			if (error) {
+// 				return reject(error);
+// 			}
 
-			if (response.statusCode !== 200) {
-				const err = new Error(__('Request failed with HTTP status code %s %s', response.statusCode, http.STATUS_CODES[response.statusCode] || ''));
-				err.statusCode = response.statusCode;
-				return reject(err, null);
-			}
+// 			if (response.statusCode !== 200) {
+// 				const err = new Error(__('Request failed with HTTP status code %s %s', response.statusCode, http.STATUS_CODES[response.statusCode] || ''));
+// 				err.statusCode = response.statusCode;
+// 				return reject(err, null);
+// 			}
 
-			let json;
-			try {
-				json = JSON.parse(body);
-			} catch (ex) {
-				return reject(ex, null);
-			}
-			resolve(json);
-		});
-	});
-}
+// 			let json;
+// 			try {
+// 				json = JSON.parse(body);
+// 			} catch (ex) {
+// 				return reject(ex, null);
+// 			}
+// 			resolve(json);
+// 		});
+// 	});
+// }
 
 /**
  * Wraps a Promise so that if it throws an Error (rejects) we re-wrap to treat it as success (we call resolve(error))

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -24,7 +24,6 @@ var appc = require('node-appc'),
 	request = require('request'),
 	sdk = require('./sdk'),
 	temp = require('temp'),
-	url = require('url'),
 	afs = appc.fs,
 	mixObj = appc.util.mixObj,
 	i18n = appc.i18n(__dirname),
@@ -1226,7 +1225,7 @@ SetupScreens.prototype.network = function app(callback) {
 		promptLabel: __('Proxy server URL'),
 		default: defaultProxy,
 		validate: function (value) {
-			var u = url.parse(value);
+			var u = new URL(value);
 			if (!/^https?:$/.test(u.protocol)) {
 				throw new Error(__('HTTP proxy url protocol must be either "http" or "https" (ex: http://user:pass@example.com)'));
 			}

--- a/tests/commands/test-sdk.js
+++ b/tests/commands/test-sdk.js
@@ -67,8 +67,11 @@ describe('sdk', () => {
 						return finished(err);
 					}
 					logger.calls[0].should.eql([ 'banner', undefined ]);
-					logger.calls[1].should.eql([ 'log', 'No Titanium SDKs are installed\n' ]);
-					logger.calls[2].should.eql([ 'log', `You can download the latest Titanium SDK by running: ${('titanium sdk install').cyan}\n` ]);
+					logger.calls[1].should.eql([ 'log', 'SDK Install Locations:' ]);
+					// call 2 is the install location path
+					logger.calls[3].should.eql([ 'log', undefined ]);
+					logger.calls[4].should.eql([ 'log', 'No Titanium SDKs are installed\n' ]);
+					logger.calls[5].should.eql([ 'log', `You can download the latest Titanium SDK by running: ${('titanium sdk install').cyan}\n` ]);
 					finished();
 				});
 			});

--- a/tests/resources/sdks/mobilesdk/osx/9.2.0.GA/manifest.json
+++ b/tests/resources/sdks/mobilesdk/osx/9.2.0.GA/manifest.json
@@ -1,1 +1,1 @@
-{"name":"9.2.0.v20200923092031","version":"9.2.0","moduleAPIVersion":{"iphone":"2","android":"4"},"timestamp":"9/23/2020 16:25","githash":"58a34e529d","platforms":["iphone","android"]}
+{"name":"9.2.0.v20200923092031","version":"9.2.0","moduleAPIVersion":{"iphone":"2","android":"4"},"timestamp":"10/15/2030 11:39","githash":"58a34e529d","platforms":["iphone","android"]}


### PR DESCRIPTION
This PR fixes the outstanding issue where it fails processing the list of releases. It tries to destructure a regex result, but blows up if the result is null. You can't destructure null.

`ti sdk list -r` has always returned GA releases. It has never returned non-GA releases. We can possibly add a flag to list non-GA releases in the future.

Here's a list of other things I fixed:
 * Fixed support for installing RC and beta release, though they do not show up when you list releases
 * Removed unused variables causing lint warnings
 * Updated `setup` command to use the not-so-new-anymore `new URL()` instead of the old `url.parse()`
 * Disabled the `ti sdk list -b` flag as branches are not supported
 * Disabled the `ti sdk list --branch <name>` option as branches are not supported

Fixes #581.