### PR TITLE
fix: Allow SDK directories to contain any version suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-6.1.0
+6.1.1 (7/13/2022)
+-------------------
+ * Allow SDK directories to contain any version suffix
+
+6.1.0 (6/28/2022)
 -------------------
  * Re-enabled installing CI builds
  * Updated minor/patch dependencies

--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -30,7 +30,11 @@ exports.desc = 'manages installed Titanium SDKs';
 /** @namespace SdkSubcommands */
 const SdkSubcommands = {};
 
-const versionRegExp = /^(\d+)\.(\d+)\.(\d+)(?:\.\w+)?$/i;
+// X.Y.Z
+// X.Y.Z.GA or X.Y.Z.RC or X.Y.Z.GA.foo or X.Y.Z.GA.foo.bar
+// X.Y.Z.foo or X.Y.Z.foo.bar
+const versionRegExp = /^(\d+)\.(\d+)\.(\d+)(?:\.\w+)?/i;
+
 const sortTypes = [ 'beta', 'rc', 'ga' ];
 const releaseTypeMap = {
 	latest: 'ga',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"mobile web",
 		"appc-client"
 	],
-	"version": "6.1.0",
+	"version": "6.1.1",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"bugs": {
 		"url": "https://github.com/tidev/titanium_mobile/issues"


### PR DESCRIPTION
`ti sdk select` would blow up because it couldn't handle SDK directories such as `11.0.0.GA.foo`. I relaxed the regex and now it works.

Fixes #587 