### PR TITLE
feat(all): add sdk select message

### DIFF
--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -900,7 +900,7 @@ async function install(logger, config, cli) {
 		config.save();
 	}
 
-	logger.log(`Titanium SDK ${name.cyan} successfully installed`);
+	logger.log(`\nTitanium SDK ${name.cyan} successfully installed. Run '${`${cli.argv.$} sdk select`.cyan}' to select your main Titanium SDK.\n`);
 }
 
 /**

--- a/tests/commands/test-sdk.js
+++ b/tests/commands/test-sdk.js
@@ -359,7 +359,7 @@ describe('sdk', () => {
 						logger.calls[3].should.eql([ 'log', 'Extracting SDK' ]);
 						logger.calls[4].should.eql([ 'log', '\n' ]); // end of progress bar
 						// Installing SDK files to...
-						logger.calls[6].should.eql([ 'log', `Titanium SDK ${'7.5.0.GA'.cyan} successfully installed` ]);
+						logger.calls[6].should.eql([ 'log', `\nTitanium SDK ${'7.5.0.GA'.cyan} successfully installed. Run '${`${cli.argv.$} sdk select`.cyan}' to select your main Titanium SDK.\n` ]);
 					} catch (error) {
 						return finished(error);
 					} finally {


### PR DESCRIPTION
Will show this message after installing the SDK:

![Screenshot_20220728_185757](https://user-images.githubusercontent.com/4334997/181595317-061f9443-8bd2-49f4-a948-86b8de871b90.png)

(or `ti sdk select` if you use the short form). Also added a blank before and after the line so its more visible.

I didn't want to put the SDK version in the command so you'll see the full list. Less to remember for the user and more options while running this command.