### PR TITLE
feat: remove email in quicksetup

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -210,16 +210,6 @@ function SetupScreens(logger, config, cli) {
 					return true;
 				}
 			}),
-			email: fields.text({
-				default: config.get('user.email', ''),
-				title: __('What is your email address used for logging into the Appcelerator Network?'),
-				validate: function (value) {
-					if (!value) {
-						throw new Error(__('Invalid e-mail address'));
-					}
-					return true;
-				}
-			}),
 			locale: fields.text({
 				default: config.get('user.locale', ''),
 				title: __('What would you like as your default locale?'),
@@ -423,7 +413,6 @@ SetupScreens.prototype.quick = function quick(callback) {
 
 		fields.set({
 			name: this._registry.user.name,
-			email: this._registry.user.email,
 			locale: this._registry.user.locale,
 			sdk: this._registry.sdk.selected(),
 			workspace: this._registry.app.workspace,
@@ -442,7 +431,6 @@ SetupScreens.prototype.quick = function quick(callback) {
 				var values = {
 					user: {
 						name: data.name,
-						email: data.email,
 						locale: data.locale
 					},
 					sdk: {
@@ -1167,7 +1155,6 @@ SetupScreens.prototype.user = function user(callback) {
 	this._title(__('User Information'));
 	fields.set({
 		name: this._registry.user.name,
-		email: this._registry.user.email,
 		locale: this._registry.user.locale
 	}).prompt(function (err, data) {
 		!err && this._save({ user: data });

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -68,9 +68,9 @@ exports.run = function (logger, config, cli, finished) {
 			case 'report':
 				logger.banner();
 				if (results.auth.loggedIn) {
-					logger.log(__('You are currently %s as %s', 'logged in'.cyan, results.auth.email.cyan) + '\n');
+					logger.log(__('You are currently logged in'.cyan) + '\n');
 				} else {
-					logger.log(__('You are currently %s', 'logged out'.cyan) + '\n');
+					logger.log(__('You are currently logged out'.cyan) + '\n');
 				}
 				break;
 			case 'json':


### PR DESCRIPTION
Removes the question for `What is your email address used for logging into the Appcelerator Network?` from the quick setup. It shouldn't be used anymore and we don't need it in the config.json

