### PR TITLE
fix: gradle warning color

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -136,6 +136,12 @@ consoul.log = function (level, msg, meta, callback) {
 	this.colorize || (msg = msg.stripColors);
 
 	if (this.colorize) {
+
+		// move gradle warnings into warn level instead of error
+		if (msg.includes('[GRADLE] Warning:')) {
+			level = 'warn';
+		}
+
 		if (level === 'warn') {
 			msg = msg.stripColors.yellow;
 		} else if (level === 'error') {


### PR DESCRIPTION
Will show the gradle warnings as warnings and not as errors:

![Screenshot_20221230_114735](https://user-images.githubusercontent.com/4334997/210062035-8f0429e7-d4f1-401c-9c87-19fbcb46cc10.png)
